### PR TITLE
add keyboardShouldPersistTaps of ScrollView

### DIFF
--- a/src/DefaultTabBar.native.tsx
+++ b/src/DefaultTabBar.native.tsx
@@ -193,6 +193,7 @@ export class DefaultTabBar extends React.PureComponent<PropsType, StateType> {
       styles = defaultStyles,
       tabsContainerStyle,
       renderUnderline,
+      keyboardShouldPersistTaps,
     } = this.props;
 
     const tabUnderlineStyle = {
@@ -231,6 +232,7 @@ export class DefaultTabBar extends React.PureComponent<PropsType, StateType> {
         bounces={false}
         scrollsToTop={false}
         scrollEnabled={tabs.length > page}
+        keyboardShouldPersistTaps={keyboardShouldPersistTaps}
       >
         <View
           style={{

--- a/src/Tabs.native.tsx
+++ b/src/Tabs.native.tsx
@@ -67,7 +67,7 @@ export class Tabs extends Component<PropsType, StateType> {
   }
 
   renderContent = (getSubElements = this.getSubElements()) => {
-    const { tabs, usePaged, destroyInactiveTab } = this.props;
+    const { tabs, usePaged, destroyInactiveTab, keyboardShouldPersistTaps } = this.props;
     const { currentTab = 0, containerWidth = 0 } = this.state;
 
     const AnimatedScrollView = this.AnimatedScrollView;
@@ -85,6 +85,7 @@ export class Tabs extends Component<PropsType, StateType> {
       directionalLockEnabled
       alwaysBounceVertical={false}
       keyboardDismissMode="on-drag"
+      keyboardShouldPersistTaps={keyboardShouldPersistTaps}
     >
       {
         tabs.map((tab, index) => {
@@ -148,7 +149,7 @@ export class Tabs extends Component<PropsType, StateType> {
   }
 
   render() {
-    const { tabBarPosition, styles = Styles, noRenderContent } = this.props;
+    const { tabBarPosition, styles = Styles, noRenderContent, keyboardShouldPersistTaps } = this.props;
     const { scrollX, scrollValue, containerWidth } = this.state;
     // let overlayTabs = (this.props.tabBarPosition === 'overlayTop' || this.props.tabBarPosition === 'overlayBottom');
     let overlayTabs = false;
@@ -156,6 +157,7 @@ export class Tabs extends Component<PropsType, StateType> {
     let tabBarProps = {
       ...this.getTabBarBaseProps(),
 
+      keyboardShouldPersistTaps,
       scrollX: scrollX,
       scrollValue: scrollValue,
       containerWidth: containerWidth,


### PR DESCRIPTION
问题描述：
1.当某个screen中有TextInput和tabs，且TextInput聚焦的时候，点击需要切换tab标签不会触发tab切换动作，而是触发TextInput的blur，当再次点击tab标签时才会触发tab的操作。

解决办法：
需要在scrollView添加属性 keyboardShouldPersistTaps=“always”
参考文档：[https://facebook.github.io/react-native/docs/scrollview.html#keyboardshouldpersisttaps](https://facebook.github.io/react-native/docs/scrollview.html#keyboardshouldpersisttaps)

例如：
```
import { Tabs } from 'antd-mobile';
import {TextInput,View} from 'react-native'

const tabs = [
  { title: 'First Tab' },
  { title: 'Second Tab' },
  { title: 'Third Tab' },
];

const TabExample = () => (
  <View>
    <Tabs tabs={tabs}>
        <View>
           <TextInput/>
        </View>
        <View>
           <Text>Second Tab</Text>
        </View>
       <View>
          <Text>Third Tab</Text>
        </View>
    </Tabs>
  </View>
);
```