### PR TITLE
在 defaultTabBar的renderTab中 添加 index 参数

### DIFF
--- a/src/DefaultTabBar.tsx
+++ b/src/DefaultTabBar.tsx
@@ -159,7 +159,7 @@ export class DefaultTabBar extends React.PureComponent<PropsType, StateType> {
       className={cls}
       onClick={() => this.onPress(i)}
     >
-      {renderTab ? renderTab(t) : t.title}
+      {renderTab ? renderTab(t, i) : t.title}
     </div>;
   }
 

--- a/src/PropsType.ts
+++ b/src/PropsType.ts
@@ -10,7 +10,7 @@ export interface TabBarPropsType {
   /** use animate | default: true */
   animated: boolean;
   /** render the tab of tabbar */
-  renderTab?: (tab: Models.TabData) => React.ReactNode;
+  renderTab?: (tab: Models.TabData, index: number) => React.ReactNode;
   /** render the underline of tabbar */
   renderUnderline?: (style: React.CSSProperties | any) => React.ReactNode;
   /** page size of tabbar's tab | default: 5 */


### PR DESCRIPTION
我最近在tabs的基础上封装了一个业务逻辑比较复杂的tab切换组件，我使用了defaultTabBar的renderTab丰富了tab按钮的样式，但是我通过renderTab渲染自定义组件时，无法便捷地拿到index，只能把原数据遍历一遍才能间接的获取index，这样会导致我的页面非常卡顿，所以我希望在执行renderTab函数时把index作为第二参数传递下去